### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,46 +13,6 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    build:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v3.3.0
-        - uses: actions/cache@v3
-          with:
-            path: |
-              ~/.cargo/bin/
-              ~/.cargo/registry/index/
-              ~/.cargo/registry/cache/
-              ~/.cargo/git/db/
-            key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        - uses: actions/cache@v3
-          with:
-            path: |
-              target/
-            key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}
-        - name: Build (w/ release flag)
-          run: |-
-            cargo build --workspace
-            build:
-              runs-on: ubuntu-latest
-              steps:
-                - uses: actions/checkout@v3.3.0
-                - uses: actions/cache@v3
-                  with:
-                    path: |
-                      ~/.cargo/bin/
-                      ~/.cargo/registry/index/
-                      ~/.cargo/registry/cache/
-                      ~/.cargo/git/db/
-                    key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-                - uses: actions/cache@v3
-                  with:
-                    path: |
-                      target/
-                    key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}
-                - name: Build
-                  run: |-
-                    cargo build --workspace --release
     update-changelog:
         runs-on: ubuntu-latest
         permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            version:
+                description: 'New version'
+                required: true
+                type: string
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    build:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3.3.0
+        - uses: actions/cache@v3
+          with:
+            path: |
+              ~/.cargo/bin/
+              ~/.cargo/registry/index/
+              ~/.cargo/registry/cache/
+              ~/.cargo/git/db/
+            key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        - uses: actions/cache@v3
+          with:
+            path: |
+              target/
+            key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}
+        - name: Build (w/ release flag)
+          run: |-
+            cargo build --workspace
+            build:
+              runs-on: ubuntu-latest
+              steps:
+                - uses: actions/checkout@v3.3.0
+                - uses: actions/cache@v3
+                  with:
+                    path: |
+                      ~/.cargo/bin/
+                      ~/.cargo/registry/index/
+                      ~/.cargo/registry/cache/
+                      ~/.cargo/git/db/
+                    key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+                - uses: actions/cache@v3
+                  with:
+                    path: |
+                      target/
+                    key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}
+                - name: Build
+                  run: |-
+                    cargo build --workspace --release
+    update-changelog:
+        runs-on: ubuntu-latest
+        permissions:
+          contents: write
+        steps:
+            - uses: actions/checkout@v3.3.0
+            - name: Update CHANGELOG.md
+              run: |-
+                today="$(date '+%Y-%m-%d')"
+                sed -i "" "s/## \[Unreleased\]/## \[Unreleased\]\n\n## [${{ inputs.version }}] - $today/g" 'CHANGELOG.md'
+            - uses: stefanzweifel/git-auto-commit-action@v4
+              with:
+                commit_message: "Release: ${{ inputs.version }}"
+                commit_options: '--no-verify --signoff'
+                commit_user_name: Powerd6 Automation
+                commit_user_email: release@powerd6.org
+                commit_author: Powerd6 Automation <release@powerd6.org>
+                tagging_message: "v${{ inputs.version }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "tools"
 description = "A collection of tools to support the creation of the powerd6 system."
 version = "0.1.0"
 
+[[bin]]
+name = "powerd6_cli"
+path = "src/main.rs"
+
 [workspace]
 members = ["fs", "module"]
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A collection of tools to support the creation of the [powerd6](https://powerd6.org/) system.
 
+## Usage
+
+`cargo install --git https://github.com/powerd6/tools` if you haven't cloned this repository, or simply `cargo install` if you have.
+
+Once installed, the `powerd6_cli` command should be available. Run it without any arguments (or with the `--help` flag) to see how to use it.
+
 ## Code of conduct
 
 See [the powerd6 Code of Conduct](https://github.com/powerd6/.github/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Add workflow to tag release.

It is meant to simplify the process of:
- Update CHANGELOG.md
- Create commit
- Tag repository
- 
This workflow does not compile the binaries nor generates a Github Release. This however, lays the groundwork for those steps to be automated.