### PR TITLE
Release with PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             - uses: stefanzweifel/git-auto-commit-action@v4
               with:
                 commit_message: "Release: ${{ inputs.version }}"
-                commit_options: '--no-verify --signoff'
+                branch: "release-${{ inputs.version }}"
                 commit_user_name: Powerd6 Automation
                 commit_user_email: release@powerd6.org
                 commit_author: Powerd6 Automation <release@powerd6.org>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
               with:
                 commit_message: "Release: ${{ inputs.version }}"
                 branch: "release-${{ inputs.version }}"
+                create_branch: true
                 commit_user_name: Powerd6 Automation
                 commit_user_email: release@powerd6.org
                 commit_author: Powerd6 Automation <release@powerd6.org>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             - name: Update CHANGELOG.md
               run: |-
                 today="$(date '+%Y-%m-%d')"
-                sed -i "" "s/## \[Unreleased\]/## \[Unreleased\]\n\n## [${{ inputs.version }}] - $today/g" 'CHANGELOG.md'
+                sed -i -e "s/## \[Unreleased\]/## \[Unreleased\]\n\n## [${{ inputs.version }}] - $today/g" 'CHANGELOG.md'
             - uses: stefanzweifel/git-auto-commit-action@v4
               with:
                 commit_message: "Release: ${{ inputs.version }}"


### PR DESCRIPTION
To avoid having to implement fancy (and dangerous) protection bypasses to branch protection, we update the release workflow to create a PR instead of pushing directly to main.