### PR TITLE
Automate creation of releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Prepare Release
 
 on:
     workflow_dispatch:
@@ -22,7 +22,7 @@ jobs:
             - name: Update CHANGELOG.md
               run: |-
                 today="$(date '+%Y-%m-%d')"
-                sed -i "" "s/## \[Unreleased\]/## \[Unreleased\]\n\n## [${{ inputs.version }}] - $today/g" 'CHANGELOG.md'
+                sed -i -e "s/## \[Unreleased\]/## \[Unreleased\]\n\n## [${{ inputs.version }}] - $today/g" 'CHANGELOG.md'
             - uses: stefanzweifel/git-auto-commit-action@v4
               with:
                 commit_message: "Release: ${{ inputs.version }}"
@@ -30,4 +30,3 @@ jobs:
                 commit_user_name: Powerd6 Automation
                 commit_user_email: release@powerd6.org
                 commit_author: Powerd6 Automation <release@powerd6.org>
-                tagging_message: "v${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,5 @@ jobs:
                 branch: "release-v${{ inputs.version }}"
                 title: "Release: ${{ inputs.version }}"
                 body: "Automated changes for release of v${{ inputs.version }}"
+                labels: |-
+                  🔒 staff only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
             - uses: stefanzweifel/git-auto-commit-action@v4
               with:
                 commit_message: "Release: ${{ inputs.version }}"
-                commit_options: '--no-verify --signoff'
                 commit_user_name: Powerd6 Automation
                 commit_user_email: release@powerd6.org
                 commit_author: Powerd6 Automation <release@powerd6.org>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            version:
+                description: 'New version'
+                required: true
+                type: string
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    update-changelog:
+        runs-on: ubuntu-latest
+        permissions:
+          contents: write
+        steps:
+            - uses: actions/checkout@v3.3.0
+            - name: Update CHANGELOG.md
+              run: |-
+                today="$(date '+%Y-%m-%d')"
+                sed -i "" "s/## \[Unreleased\]/## \[Unreleased\]\n\n## [${{ inputs.version }}] - $today/g" 'CHANGELOG.md'
+            - uses: stefanzweifel/git-auto-commit-action@v4
+              with:
+                commit_message: "Release: ${{ inputs.version }}"
+                commit_options: '--no-verify --signoff'
+                commit_user_name: Powerd6 Automation
+                commit_user_email: release@powerd6.org
+                commit_author: Powerd6 Automation <release@powerd6.org>
+                tagging_message: "v${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,28 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    update-changelog:
+    prepare-pull-request:
         runs-on: ubuntu-latest
         permissions:
           contents: write
+          pull-requests: write
         steps:
             - uses: actions/checkout@v3.3.0
             - name: Update CHANGELOG.md
               run: |-
                 today="$(date '+%Y-%m-%d')"
                 sed -i -e "s/## \[Unreleased\]/## \[Unreleased\]\n\n## [${{ inputs.version }}] - $today/g" 'CHANGELOG.md'
-            - uses: stefanzweifel/git-auto-commit-action@v4
+            - name: Push branch
+              uses: stefanzweifel/git-auto-commit-action@v4
               with:
-                commit_message: "Release: ${{ inputs.version }}"
+                commit_message: "Update changelog: v${{ inputs.version }}"
                 commit_user_name: Powerd6 Automation
                 commit_user_email: release@powerd6.org
-                commit_author: Powerd6 Automation <release@powerd6.org>
+                create_branch: true
+                branch: "release-v${{ inputs.version }}"
+            - name: Create Pull Request
+              uses: peter-evans/create-pull-request@v5
+              with:
+                branch: "release-v${{ inputs.version }}"
+                title: "Release: ${{ inputs.version }}"
+                body: "Automated changes for release of v${{ inputs.version }}"


### PR DESCRIPTION
Add workflow to tag release.

It is meant to simplify the process of:
- Create new branch
- Update `CHANGELOG.md`
- Create PR

This workflow does not compile the binaries nor generates a Github Release. This however, lays the groundwork for those steps to be automated.