### PR TITLE
Fix generated Identifiers for entries

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
     },
     "cSpell.words": [
         "jsonschema",
+        "pathdiff",
         "powerd6",
         "testdir",
         "thiserror"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Renamed binary from `tools` to `powerd6_cli`
 
+### Fixed
+
+- Identifiers generated for files now use their relative paths to create the correct values
+
 ## [0.1.0] - 2023-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
 name = "fs"
 version = "0.1.0"
 dependencies = [
+ "pathdiff",
  "pretty_assertions",
  "serde_json",
  "serde_yaml",
@@ -422,6 +423,12 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,12 @@ version = "0.1.0"
 name = "powerd6_cli"
 path = "src/main.rs"
 
+[dependencies]
+clap = { workspace = true, features = ["derive"] }
+fs = { workspace = true }
+module = { workspace = true }
+serde_json = { workspace = true }
+
 [workspace]
 members = ["fs", "module"]
 
@@ -14,8 +20,10 @@ members = ["fs", "module"]
 edition = "2021"
 
 [workspace.dependencies]
+clap = { version = "4.3.4", features = ["derive"] }
 fs = { path = "./fs" }
 module = { path = "./module" }
+pathdiff = "0.2.1"
 pretty_assertions = "1.3.0"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
@@ -23,9 +31,3 @@ serde_yaml = "0.9.21"
 testdir = "0.7.3"
 thiserror = "1.0"
 url = { version = "2.3.1", features = ["serde"] }
-
-[dependencies]
-clap = { version = "4.3.4", features = ["derive"] }
-fs = { workspace = true }
-module = { workspace = true }
-serde_json = { workspace = true }

--- a/fs/Cargo.toml
+++ b/fs/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
+pathdiff = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }

--- a/fs/src/identifiers.rs
+++ b/fs/src/identifiers.rs
@@ -1,0 +1,19 @@
+use crate::{path_utils::PathUtils, Entry, EntrySet};
+
+impl Entry {
+    pub fn get_id_from_nested_path(&self, entry_set: &EntrySet) -> Option<String> {
+        let entry_path = match self {
+            Entry::File(f) => f,
+            Entry::Directory {
+                root_file,
+                extra_files: _,
+            } => root_file,
+            Entry::RenderingDirectory {
+                root_file,
+                extra_files: _,
+                rendering_files: _,
+            } => root_file,
+        };
+        entry_path.get_id_from_path(&entry_set.base_path)
+    }
+}

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -86,20 +86,6 @@ impl Entry {
                 })
         }
     }
-    pub fn get_id_from_path(&self) -> String {
-        match self {
-            Entry::File(f) => f.get_name_without_extension(),
-            Entry::Directory {
-                root_file,
-                extra_files: _,
-            } => root_file.get_name_without_extension(),
-            Entry::RenderingDirectory {
-                root_file,
-                extra_files: _,
-                rendering_files: _,
-            } => root_file.get_name_without_extension(),
-        }
-    }
 }
 
 /// A collection of data objects contained within a directory.
@@ -249,8 +235,8 @@ impl TryFrom<PathBuf> for FileSystem {
         }
     }
 }
-
 pub mod data;
 pub mod file_types;
+pub mod identifiers;
 pub mod path_utils;
 pub mod sorted;

--- a/module/src/module.rs
+++ b/module/src/module.rs
@@ -118,8 +118,9 @@ impl TryFrom<FileSystem> for Module {
         match TryInto::<Module>::try_into(fs.module) {
             Ok(mut module) => {
                 if let Some(fs_types) = fs.types {
-                    let types_entries = fs_types.entries.into_iter().filter_map(|e| {
-                        Some(Identifier(e.get_id_from_path()))
+                    let types_entries = fs_types.entries.clone().into_iter().filter_map(|e| {
+                        e.get_id_from_nested_path(&fs_types)
+                            .map(Identifier)
                             .zip(TryInto::<ModuleType>::try_into(e).ok())
                     });
 
@@ -139,8 +140,10 @@ impl TryFrom<FileSystem> for Module {
                 }
 
                 if let Some(fs_contents) = fs.contents {
-                    let fs_content_data = fs_contents.entries.into_iter().filter_map(|e| {
-                        Some(Identifier(e.get_id_from_path())).zip(e.try_get_data().ok())
+                    let fs_content_data = fs_contents.entries.clone().into_iter().filter_map(|e| {
+                        e.get_id_from_nested_path(&fs_contents)
+                            .map(Identifier)
+                            .zip(e.try_get_data().ok())
                     });
 
                     let mut content_entries: HashMap<Identifier, JsonObject> = HashMap::new();


### PR DESCRIPTION
Identifiers generated for files now use their relative paths to create the correct values.

Previously they would only use the filename of the file in the `Entry`, now they use all the path to generate better identifiers.