### PR TITLE
Rebuild when releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,19 @@ jobs:
           pull-requests: write
         steps:
             - uses: actions/checkout@v3.3.0
+            - uses: actions/cache@v3
+              with:
+                path: |
+                  ~/.cargo/bin/
+                  ~/.cargo/registry/index/
+                  ~/.cargo/registry/cache/
+                  ~/.cargo/git/db/
+                key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            - uses: actions/cache@v3
+              with:
+                path: |
+                  target/
+                key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}
             - name: Update CHANGELOG.md
               run: |-
                 today="$(date '+%Y-%m-%d')"
@@ -27,6 +40,9 @@ jobs:
             - name: Update Cargo packages
               run: |-
                 sed -i -e "s/version = \"[0-9]*.[0-9]*.[0-9]*\"$/version = \"${{ inputs.version }}\"/" 'Cargo.toml'
+            - name: Rebuild packages
+              run: |-
+                cargo build --workspace
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@v5
               with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- When releasing, rebuild before opening a PR, to update `Cargo.lock`
+
+
 ## [0.1.3] - 2023-06-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tools"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "clap",
  "fs",


### PR DESCRIPTION
This helps the issue that bumping a crate version causes on `Cargo.lock`